### PR TITLE
[terminal] add alacritty config

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -1,0 +1,152 @@
+env:
+  # cf. https://gist.github.com/andersevenrud/015e61af2fd264371032763d4ed965b6
+  TERM: xterm-256color
+window:
+  padding:
+    x: 5
+    y: 5
+  opacity: 1.0
+  decorations:  full
+font:
+  normal:
+    family: 'Menlo for Powerline'
+    style: Regular
+  bold:
+    family: 'Menlo for Powerline'
+    style: Bold
+  italic:
+    family: 'Menlo for Powerline'
+    style: Italic
+  bold_italic:
+    family: 'Menlo for Powerline'
+    style: Bold Italic
+  size: 14.0
+  offset:
+    x: 0
+    y: 0
+
+# cf. https://github.com/arcticicestudio/nord-alacritty/blob/main/src/nord.yml
+colors:
+  primary:
+    background: '#2e3440'
+    foreground: '#d8dee9'
+    dim_foreground: '#a5abb6'
+  cursor:
+    text: '#2e3440'
+    cursor: '#d8dee9'
+  vi_mode_cursor:
+    text: '#2e3440'
+    cursor: '#d8dee9'
+  selection:
+    text: CellForeground
+    background: '#4c566a'
+  search:
+    matches:
+      foreground: CellBackground
+      background: '#88c0d0'
+  footer_bar: # edited: colors.search.bar -> colors.footer_bar
+      background: '#434c5e'
+      foreground: '#d8dee9'
+  normal:
+    black: '#3b4252'
+    red: '#bf616a'
+    green: '#a3be8c'
+    yellow: '#ebcb8b'
+    blue: '#81a1c1'
+    magenta: '#b48ead'
+    cyan: '#88c0d0'
+    white: '#e5e9f0'
+  bright:
+    black: '#4c566a'
+    red: '#bf616a'
+    green: '#a3be8c'
+    yellow: '#ebcb8b'
+    blue: '#81a1c1'
+    magenta: '#b48ead'
+    cyan: '#8fbcbb'
+    white: '#eceff4'
+  dim:
+    black: '#373e4d'
+    red: '#94545d'
+    green: '#809575'
+    yellow: '#b29e75'
+    blue: '#68809a'
+    magenta: '#8c738c'
+    cyan: '#6d96a5'
+    white: '#aeb3bb'
+key_bindings:
+  - { key: A,         mods: Alt,       chars: "\x1ba"                       }
+  - { key: B,         mods: Alt,       chars: "\x1bb"                       }
+  - { key: C,         mods: Alt,       chars: "\x1bc"                       }
+  - { key: D,         mods: Alt,       chars: "\x1bd"                       }
+  - { key: E,         mods: Alt,       chars: "\x1be"                       }
+  - { key: F,         mods: Alt,       chars: "\x1bf"                       }
+  - { key: G,         mods: Alt,       chars: "\x1bg"                       }
+  - { key: H,         mods: Alt,       chars: "\x1bh"                       }
+  - { key: I,         mods: Alt,       chars: "\x1bi"                       }
+  - { key: J,         mods: Alt,       chars: "\x1bj"                       }
+  - { key: K,         mods: Alt,       chars: "\x1bk"                       }
+  - { key: L,         mods: Alt,       chars: "\x1bl"                       }
+  - { key: M,         mods: Alt,       chars: "\x1bm"                       }
+  - { key: N,         mods: Alt,       chars: "\x1bn"                       }
+  - { key: O,         mods: Alt,       chars: "\x1bo"                       }
+  - { key: P,         mods: Alt,       chars: "\x1bp"                       }
+  - { key: Q,         mods: Alt,       chars: "\x1bq"                       }
+  - { key: R,         mods: Alt,       chars: "\x1br"                       }
+  - { key: S,         mods: Alt,       chars: "\x1bs"                       }
+  - { key: T,         mods: Alt,       chars: "\x1bt"                       }
+  - { key: U,         mods: Alt,       chars: "\x1bu"                       }
+  - { key: V,         mods: Alt,       chars: "\x1bv"                       }
+  - { key: W,         mods: Alt,       chars: "\x1bw"                       }
+  - { key: X,         mods: Alt,       chars: "\x1bx"                       }
+  - { key: Y,         mods: Alt,       chars: "\x1by"                       }
+  - { key: Z,         mods: Alt,       chars: "\x1bz"                       }
+  - { key: A,         mods: Alt|Shift, chars: "\x1bA"                       }
+  - { key: B,         mods: Alt|Shift, chars: "\x1bB"                       }
+  - { key: C,         mods: Alt|Shift, chars: "\x1bC"                       }
+  - { key: D,         mods: Alt|Shift, chars: "\x1bD"                       }
+  - { key: E,         mods: Alt|Shift, chars: "\x1bE"                       }
+  - { key: F,         mods: Alt|Shift, chars: "\x1bF"                       }
+  - { key: G,         mods: Alt|Shift, chars: "\x1bG"                       }
+  - { key: H,         mods: Alt|Shift, chars: "\x1bH"                       }
+  - { key: I,         mods: Alt|Shift, chars: "\x1bI"                       }
+  - { key: J,         mods: Alt|Shift, chars: "\x1bJ"                       }
+  - { key: K,         mods: Alt|Shift, chars: "\x1bK"                       }
+  - { key: L,         mods: Alt|Shift, chars: "\x1bL"                       }
+  - { key: M,         mods: Alt|Shift, chars: "\x1bM"                       }
+  - { key: N,         mods: Alt|Shift, chars: "\x1bN"                       }
+  - { key: O,         mods: Alt|Shift, chars: "\x1bO"                       }
+  - { key: P,         mods: Alt|Shift, chars: "\x1bP"                       }
+  - { key: Q,         mods: Alt|Shift, chars: "\x1bQ"                       }
+  - { key: R,         mods: Alt|Shift, chars: "\x1bR"                       }
+  - { key: S,         mods: Alt|Shift, chars: "\x1bS"                       }
+  - { key: T,         mods: Alt|Shift, chars: "\x1bT"                       }
+  - { key: U,         mods: Alt|Shift, chars: "\x1bU"                       }
+  - { key: V,         mods: Alt|Shift, chars: "\x1bV"                       }
+  - { key: W,         mods: Alt|Shift, chars: "\x1bW"                       }
+  - { key: X,         mods: Alt|Shift, chars: "\x1bX"                       }
+  - { key: Y,         mods: Alt|Shift, chars: "\x1bY"                       }
+  - { key: Z,         mods: Alt|Shift, chars: "\x1bZ"                       }
+  - { key: Key1,      mods: Alt,       chars: "\x1b1"                       }
+  - { key: Key2,      mods: Alt,       chars: "\x1b2"                       }
+  - { key: Key3,      mods: Alt,       chars: "\x1b3"                       }
+  - { key: Key4,      mods: Alt,       chars: "\x1b4"                       }
+  - { key: Key5,      mods: Alt,       chars: "\x1b5"                       }
+  - { key: Key6,      mods: Alt,       chars: "\x1b6"                       }
+  - { key: Key7,      mods: Alt,       chars: "\x1b7"                       }
+  - { key: Key8,      mods: Alt,       chars: "\x1b8"                       }
+  - { key: Key9,      mods: Alt,       chars: "\x1b9"                       }
+  - { key: Key0,      mods: Alt,       chars: "\x1b0"                       }
+  - { key: Space,     mods: Control,   chars: "\x00"                        } # Ctrl + Space
+  - { key: Grave,     mods: Alt,       chars: "\x1b`"                       } # Alt + `
+  - { key: Grave,     mods: Alt|Shift, chars: "\x1b~"                       } # Alt + ~
+  - { key: Period,    mods: Alt,       chars: "\x1b."                       } # Alt + .
+  - { key: Key8,      mods: Alt|Shift, chars: "\x1b*"                       } # Alt + *
+  - { key: Key3,      mods: Alt|Shift, chars: "\x1b#"                       } # Alt + #
+  - { key: Period,    mods: Alt|Shift, chars: "\x1b>"                       } # Alt + >
+  - { key: Comma,     mods: Alt|Shift, chars: "\x1b<"                       } # Alt + <
+  - { key: Minus,     mods: Alt|Shift, chars: "\x1b_"                       } # Alt + _
+  - { key: Key5,      mods: Alt|Shift, chars: "\x1b%"                       } # Alt + %
+  - { key: Key6,      mods: Alt|Shift, chars: "\x1b^"                       } # Alt + ^
+  - { key: Backslash, mods: Alt,       chars: "\x1b\\"                      } # Alt + \
+  - { key: Backslash, mods: Alt|Shift, chars: "\x1b|"                       } # Alt + |

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -73,6 +73,7 @@ let g:airline_section_z = get(g:, 'airline_linecolumn_prefix', '').'[%2p%%]%4l/%
 " color scheme
 """""""""""""""""""""""
 set background=dark
+set termguicolors
 colorscheme nord
 
 """""""""""""""""""""""

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -53,8 +53,8 @@ bind-key -T copy-mode-vi Enter send -X copy-selection
 bind-key C-p paste-buffer
 
 # Enable 256 color
-set-option -g default-terminal "xterm-256color"
-set-option -ga terminal-overrides ",xterm-256color:Tc"
+set-option -g default-terminal "$TERM"
+set-option -ga terminal-overrides ",$TERM:RGB"
 
 # Add color theme
 # source-file ~/.tmux/iceberg_minimal.tmux.conf


### PR DESCRIPTION
iTerm2でのvimスクロールが重かったのでAlacrittyを使う
参考：https://gist.github.com/andersevenrud/015e61af2fd264371032763d4ed965b6